### PR TITLE
KAS-5023: Session polling

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -226,7 +226,7 @@ get '/sessions/current/?' do
   status 200
   {
     links: {
-      self: rewrite_url.chomp('/') + '/current'
+      self: rewrite_url.chomp('/')
     },
     data: {
       type: 'sessions',


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5023

Correctly generate the related link when getting the current session (previously, `/current` was appended and the generated URL would be `/mock/sessions/current/current`).